### PR TITLE
Use the CakePHP plugin installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "sizuhiko/Bdd",
+    "type": "cakephp-plugin",
     "description": "BddPlugin for CakePHP2",
     "authors": [
         {
@@ -56,6 +57,7 @@
         }
     ],    
     "require": {
+        "composer/installers": "*",
         "behat/mink-extension": "*",
         "pear-phpunit/Object_Freezer": "*",
         "pear-pear/Console_CommandLine": "*",


### PR DESCRIPTION
Composerのカスタムインストーラーとして用意されているCakePHPプラグイン用のインストーラーを利用するかたちとして、composer.jsonファイルにtypeフィールドを追加してみました。

丁度こちらのリンク先にCakePHPプラグインでの説明が記載されており、それを参考にしています。
[composer/installers · GitHub](/composer/installers#example-composerjson-file)

ご存知かと思いますが、CakePHPプラグイン用のインストーラーを使うことによって、BddプラグインをCakePHPのPluginディレクトリ内にインストールすることができます。

これに伴い、README.mdに書かれているInstallの説明を変更していただくことが望ましいかと考えています。例えば、次のようなかたちです。

```
cd /path/to/cakephp/app
vi composer.json
curl -s https://getcomposer.org/installer | php
php composer.phar install --dev
```

例）composer.json

```
{
    "config": {
        "vendor-dir": "Vendor"
    },
    "minimum-stability": "dev",
    "repositories": [
        {
            "type": "vcs",
            "url": "git://github.com/sizuhiko/Bdd.git"
        }
    ],
    "require": {
        "cakephp/debug_kit": "2.2.*@dev",
        "cakedc/migrations": "dev-master"
    },
    "require-dev": {
        "sizuhiko/Bdd": "dev-master"
    }
}
```

現在、Bddプラグインが必要とするその他のモジュールがインストールできず、BddプラグインまたはCakePHPアプリケーション側の何れかのcomposer.jsonを変更する必要がありそうです。
ひとまず、Pull Requestをお送りいたします。
